### PR TITLE
Add check if transaction step names are unique

### DIFF
--- a/include/gisla.hrl
+++ b/include/gisla.hrl
@@ -15,6 +15,7 @@
 -type gisla_name() :: atom() | binary() | string().
 
 -record(step, {
+                ref :: reference(),
                name :: gisla_name(),
             forward :: #operation{},
            rollback :: #operation{}


### PR DESCRIPTION
Transactions step names must be unique. Otherwise, function update_transaction/2 will update wrong step, because function lists:keyreplace(N, #step.name, S, Step) always updates first occurrence of Step with name N.