### PR TITLE
Do not send timer cancel info

### DIFF
--- a/src/gisla.erl
+++ b/src/gisla.erl
@@ -199,7 +199,7 @@ update_step(Step, forward, {Reply, Func, State}) ->
 do_step(Name, Func, State) ->
     {F, Timeout} = make_closure(Func, self(), State),
     {Pid, Mref} = spawn_monitor(fun() -> F() end),
-    ?log(info, "Started pid ~p to execute step ~p", [Pid, Name]),
+    ?log(debug, "Started pid ~p to execute step ~p", [Pid, Name]),
     TRef = erlang:start_timer(Timeout, self(), timeout),
     handle_loop_return(loop(Mref, Pid, TRef, State, false), Func).
 
@@ -214,7 +214,7 @@ loop(Mref, Pid, TRef, State, NormalExitRcvd) ->
             ?log(debug, "Normal exit received, with no failure messages out of order."),
             {ok, normal, State};
         {complete, NewState} ->
-            ?log(info, "Step sent complete..."),
+            ?log(debug, "Step sent complete..."),
             demonitor(Mref, [flush]), %% prevent us from getting any spurious failures and clean out our mailbox
             self() ! race_conditions_are_bad_mmmkay,
             erlang:cancel_timer(TRef, [{async, true}, {info, false}]),

--- a/src/gisla.erl
+++ b/src/gisla.erl
@@ -217,7 +217,7 @@ loop(Mref, Pid, TRef, State, NormalExitRcvd) ->
             ?log(info, "Step sent complete..."),
             demonitor(Mref, [flush]), %% prevent us from getting any spurious failures and clean out our mailbox
             self() ! race_conditions_are_bad_mmmkay,
-            erlang:cancel_timer(TRef, [{async, true}]),
+            erlang:cancel_timer(TRef, [{async, true}, {info, false}]),
             loop(Mref, Pid, undef, NewState, true);
         {checkpoint, NewState} ->
             ?log(debug, "Got a checkpoint state"),
@@ -229,7 +229,7 @@ loop(Mref, Pid, TRef, State, NormalExitRcvd) ->
         {'DOWN', Mref, process, Pid, Reason} ->
             %% We crashed for some reason
             ?log(error, "Pid ~p failed because ~p", [Pid, Reason]),
-            erlang:cancel_timer(TRef, [{async, true}]),
+            erlang:cancel_timer(TRef, [{async, true}, {info, false}]),
             {failed, Reason, State};
         {timeout, TRef, _} ->
             case NormalExitRcvd of


### PR DESCRIPTION
Problem:
* OTP defaults to sending `{cancel_timer, Ref, Result}` messages when `{async, true}` is used with an erlang:cancel_timer/2 call. This results in unnecessary logging spam when the loop function discards the message.

Solution:
* Set `{info, false}` so these messages are not sent by OTP.